### PR TITLE
[COGF-46] Borda inferior no tiles de produto

### DIFF
--- a/src/components/content/LoginContent/LoginContent.scss
+++ b/src/components/content/LoginContent/LoginContent.scss
@@ -5,6 +5,7 @@
       margin: 0 auto;
       max-width: $screen-m;
       text-align: center;
+      border-bottom: 3px solid $tertiary;
    }
 
    .form-options {

--- a/src/components/tiles/ProductTile/ProductTile.jsx
+++ b/src/components/tiles/ProductTile/ProductTile.jsx
@@ -26,7 +26,7 @@ export default function ProductTile({ product, className = '' }) {
    }
 
    return (
-      <Card className={classes} elevation="l" padding="none">
+      <Card className={classes} elevation="l" padding="none" radius="s">
          <ImagePlaceholder />
 
          <div className="product-info">

--- a/src/components/tiles/ProductTile/ProductTile.scss
+++ b/src/components/tiles/ProductTile/ProductTile.scss
@@ -1,6 +1,8 @@
 @use '@/styles/variables.scss' as *;
 
 .ProductTile {
+   border-bottom: 3px solid $tertiary;
+
    .product-info {
       padding: $padding-m;
 


### PR DESCRIPTION
## [COGF-46] Descrição
Implementado a borda inferior para o tile de produto e o card dos formulários de login.

This pull request introduces minor visual updates to the `LoginContent` and `ProductTile` components, focusing on styling changes to improve consistency and enhance the UI.

Styling updates:

* [`src/components/content/LoginContent/LoginContent.scss`](diffhunk://#diff-381f18b77b3c462707e07ce4f88354961075f5f095d1d29fe8c6ff348cd46f0aR8): Added a `border-bottom` with a thickness of 3px and color `$tertiary` to the `.LoginContent` container for improved visual distinction.
* [`src/components/tiles/ProductTile/ProductTile.scss`](diffhunk://#diff-d64ad9c078099eae724827617bd7867594d49af57b2c4a1806a428f1e649db19R4-R5): Added a `border-bottom` with the same styling (`3px solid $tertiary`) to the `.ProductTile` component for consistency across elements.

Component enhancements:

* [`src/components/tiles/ProductTile/ProductTile.jsx`](diffhunk://#diff-d68e778b309d5d0c68b31dae0f24cd65c2eeaff8fed173fc2ad1a933585dc355L29-R29): Updated the `Card` component within `ProductTile` to include a `radius="s"` property, adding rounded corners for a more polished look.