### PR TITLE
[COGF-53] Erros nas variaveis de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 API_ROOT=http://localhost:8000
-CLIENT_API_ROOT=http://localhost:8000 # Se você for rodar o frontend em uma rede diferente do backend, ajuste essa URL para apontar corretamente as requisições para o backend.
+NEXT_PUBLIC_API_ROOT=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Este projeto é um teste técnico desenvolvido para a Cogna, com foco em boas pr
 
 </details>
 
+#### Teste a aplicação na nuvem
+Você pode acessar a aplicação hospedada na nuvem através do seguinte link: [Teste rodando na nuvem](http://91.99.8.161:3000/).
+- Como está sem SSL, pode ser necessário aceitar o aviso de segurança do navegador.
+
 ## Principais decisões técnicas
 ### 1. Roteamento baseado em `/pages` com Server Side Rendering (SSR)
 Optei por utilizar a abordagem de roteamento baseada na pasta `/pages`, pois ela simplifica a configuração das rotas e torna o mapeamento entre URLs e componentes mais intuitivo. Além disso, utilizei Server Side Rendering (SSR) para as duas rotas otimizando o carregamento inicial das páginas e melhorar o SEO, permitindo que mecanismos de busca indexem o conteúdo de forma mais eficiente e proporcionando uma experiência mais rápida para o usuário, especialmente em buscas e acessos diretos.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Este projeto é um teste técnico desenvolvido para a Cogna, com foco em boas pr
 4. Crie um arquivo `.env` na raiz do projeto com as seguintes variáveis de ambiente:
     ```env
     API_ROOT=http://localhost:8000
-    CLIENT_API_ROOT=http://localhost:3000 # Se você for rodar o frontend em uma rede diferente do backend, ajuste essa URL para apontar corretamente as requisições para o backend.
+    NEXT_PUBLIC_API_ROOT=http://localhost:3000 # Se você for rodar o frontend em uma rede diferente do backend, ajuste essa URL para apontar corretamente as requisições para o backend.
     ```
 5. Rode o build de produção:
     ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "3000:3000"
     environment:
       - API_ROOT=http://cogna-be:8000
-      - CLIENT_API_ROOT=http://localhost:8000  # Se você for rodar o frontend em uma rede diferente do backend, ajuste essa URL para apontar corretamente as requisições para o backend.
+      - NEXT_PUBLIC_API_ROOT=http://localhost:8000  # Se você for rodar o frontend em uma rede diferente do backend, ajuste essa URL para apontar corretamente as requisições para o backend.
     networks:
       - cogna-be_default
     restart: unless-stopped

--- a/src/components/content/produto/ImportContent/ImportContent.jsx
+++ b/src/components/content/produto/ImportContent/ImportContent.jsx
@@ -8,15 +8,13 @@ import Ajax from '@/services/AJAX';
  * ImportContent component for importing products via JSON file upload.
  * Handles file selection, form submission, and displays a JSON example for users.
  *
- * @param {object} props
- * @param {string} [props.CLIENT_API_ROOT='http://localhost:8000'] - API root URL for backend requests.
  * @returns {JSX.Element}
  */
-export default function ImportContent({ CLIENT_API_ROOT = 'http://localhost:8000' }) {
+export default function ImportContent() {
    const [ file, setFile ] = useState(null);
    const [ loading, setLoading ] = useState(false);
    const router = useRouter();
-   const ajax = Ajax(CLIENT_API_ROOT);
+   const ajax = Ajax();
 
    const handleSubmit = async (event) => {
       event.preventDefault();

--- a/src/pages/produto/importar.jsx
+++ b/src/pages/produto/importar.jsx
@@ -2,30 +2,16 @@ import { ImportContent } from '@/components/content';
 import { PageBase } from '@/components/layout';
 
 /**
- * getServerSideProps provides the CLIENT_API_ROOT environment variable as a prop for SSR.
- *
- * @returns {Promise<{props: {CLIENT_API_ROOT: string}}>} Props for the page.
- */
-export async function getServerSideProps() {
-   return {
-      props: {
-         CLIENT_API_ROOT: process.env.CLIENT_API_ROOT
-      }
-   };
-}
-
-/**
  * Import page for uploading products via JSON file.
  * Wraps ImportContent in a protected PageBase layout.
  *
  * @param {object} props
- * @param {string} props.CLIENT_API_ROOT - API root URL for backend requests.
  * @returns {JSX.Element}
  */
-export default function Import({ CLIENT_API_ROOT }) {
+export default function Import() {
    return (
       <PageBase authProtected>
-         <ImportContent CLIENT_API_ROOT={CLIENT_API_ROOT} />
+         <ImportContent />
       </PageBase>
    );
 };

--- a/src/providers/AuthContext.jsx
+++ b/src/providers/AuthContext.jsx
@@ -26,7 +26,7 @@ export function AuthProvider({ loadedUser, renderIfLoading, redirectLogin, spinn
    const [ user, setUser ] = useState(loadedUser || null);
    const [ loading, setLoading ] = useState(loadedUser ? false : true);
    const router = useRouter();
-   const ajax = Ajax(process.env.CLIENT_API_ROOT);
+   const ajax = Ajax();
 
    useEffect(() => {
       if (user) {

--- a/src/services/AJAX.js
+++ b/src/services/AJAX.js
@@ -8,8 +8,6 @@ import axios from 'axios';
  * @returns {import('axios').AxiosInstance} Configured Axios instance.
  */
 export default function AJAX(API_ROOT, options) {
-   console.log(API_ROOT || process.env.API_ROOT || process.env.NEXT_PUBLIC_API_ROOT || 'http://localhost:8000');
-
    return axios.create({
       baseURL: API_ROOT || process.env.API_ROOT || process.env.NEXT_PUBLIC_API_ROOT || 'http://localhost:8000',
       withCredentials: true,

--- a/src/services/AJAX.js
+++ b/src/services/AJAX.js
@@ -8,8 +8,10 @@ import axios from 'axios';
  * @returns {import('axios').AxiosInstance} Configured Axios instance.
  */
 export default function AJAX(API_ROOT, options) {
+   console.log(API_ROOT || process.env.API_ROOT || process.env.NEXT_PUBLIC_API_ROOT || 'http://localhost:8000');
+
    return axios.create({
-      baseURL: API_ROOT || process.env.API_ROOT || 'http://localhost:8000',
+      baseURL: API_ROOT || process.env.API_ROOT || process.env.NEXT_PUBLIC_API_ROOT || 'http://localhost:8000',
       withCredentials: true,
       timeout: 30000,
       ...options


### PR DESCRIPTION
## [COGF-53] Descrição
Implementando variavle pública do nextjs para quando for rodar incluir nos arquivas env

This pull request introduces changes to standardize the use of the `NEXT_PUBLIC_API_ROOT` environment variable across the project, replacing the previously used `CLIENT_API_ROOT`. It also simplifies the handling of API root URLs in the frontend code by removing redundant props and relying on environment variables directly. The most important changes are grouped below:

### Environment Variable Standardization:
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL2-R2): Replaced `CLIENT_API_ROOT` with `NEXT_PUBLIC_API_ROOT` for consistency with Next.js conventions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32): Updated documentation to reflect the change from `CLIENT_API_ROOT` to `NEXT_PUBLIC_API_ROOT`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L9-R9): Updated the environment variable from `CLIENT_API_ROOT` to `NEXT_PUBLIC_API_ROOT` in the Docker Compose configuration.

### Frontend Code Simplification:
* [`src/components/content/produto/ImportContent/ImportContent.jsx`](diffhunk://#diff-489a2644c158cb262640fe92efa71a24ac4f3a39da7c67d1dc96e4c5f83f6c9cL11-R17): Removed the `CLIENT_API_ROOT` prop from the `ImportContent` component and updated the `Ajax` function to rely on environment variables directly.
* [`src/pages/produto/importar.jsx`](diffhunk://#diff-5be6102df25d858cf5fde8cfda35f2e46fc14f1bf38322f605d92dda4aca8c94L4-R14): Removed `getServerSideProps` and the `CLIENT_API_ROOT` prop from the `Import` page, simplifying the component.
* [`src/providers/AuthContext.jsx`](diffhunk://#diff-4949151008e60187931a818af53fa929c53744324af486a2fba9dad52d729f98L29-R29): Updated the `AuthProvider` to use `Ajax` without explicitly passing the `CLIENT_API_ROOT` environment variable.

### Backend Integration:
* [`src/services/AJAX.js`](diffhunk://#diff-b0af9856c05953f4120776553368ee12103905d176c868051e6cea6ad112fc31R11-R14): Enhanced the `Ajax` function to prioritize `NEXT_PUBLIC_API_ROOT` while maintaining backward compatibility with `API_ROOT` and added a debug log for the resolved base URL.

[COGF-53]: https://feliperamosdev.atlassian.net/browse/COGF-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ