### PR TITLE
[COGF-56] Colocar as funções de login e cadastro dentro do AuthContext

### DIFF
--- a/src/components/forms/LoginForm/LoginForm.jsx
+++ b/src/components/forms/LoginForm/LoginForm.jsx
@@ -1,6 +1,5 @@
-import { useRouter } from 'next/navigation';
 import { FormControl, FormInput } from '@/components/common';
-import Ajax from '@/services/AJAX';
+import { useAuth } from '@/providers/AuthContext';
 
 /**
  * LoginForm component for user authentication.
@@ -10,25 +9,8 @@ import Ajax from '@/services/AJAX';
  * @returns {JSX.Element}
  */
 export default function LoginForm() {
-   const router = useRouter();
-
-   const handleSubmit = async (data) => {
-      const ajax = Ajax(process.env.NEXT_PUBLIC_API_ROOT);
-
-      try {
-         const loginUser = await ajax.post('/auth/login', data);
-
-         if (!loginUser.data.success) {
-            throw loginUser;
-         }
-
-         router.push('/');
-         return loginUser.data;
-      } catch (error) {
-         const errorData = error.response ? error.response.data : error;
-         return errorData;
-      }
-   };
+   const { login } = useAuth();
+   const handleSubmit = async (data) => await login(data.email, data.password);
 
    return (
       <FormControl submitLabel="Entrar" onSubmit={handleSubmit}>

--- a/src/components/forms/LoginForm/LoginForm.test.jsx
+++ b/src/components/forms/LoginForm/LoginForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import LoginForm from './LoginForm';
+import { AuthProvider } from '@/providers/AuthContext';
 
 // Mocks
 const mockPush = jest.fn();
@@ -26,13 +27,14 @@ jest.mock('@/components/common', () => ({
 }));
 
 describe('LoginForm', () => {
+   const LoginNode = () => <AuthProvider loadedUser={{ name: 'John', email: 'john@test.com' }} notAuthRender renderIfLoading><LoginForm /></AuthProvider>
    beforeEach(() => {
       mockPost.mockReset();
       mockPush.mockReset();
    });
 
    it('renders form and inputs', () => {
-      const { getByTestId, getByText } = render(<LoginForm />);
+      const { getByTestId, getByText } = render(<LoginNode />);
       expect(getByTestId('mock-form')).toBeInTheDocument();
       expect(getByTestId('mock-input-email')).toBeInTheDocument();
       expect(getByTestId('mock-input-password')).toBeInTheDocument();
@@ -41,7 +43,7 @@ describe('LoginForm', () => {
 
    it('submits form and redirects on success', async () => {
       mockPost.mockResolvedValueOnce({ data: { success: true } });
-      const { getByTestId } = render(<LoginForm />);
+      const { getByTestId } = render(<LoginNode />);
       fireEvent.submit(getByTestId('mock-form'));
       await waitFor(() => {
          expect(mockPost).toHaveBeenCalledWith('/auth/login', { email: 'test@email.com', password: '123456' });
@@ -53,7 +55,7 @@ describe('LoginForm', () => {
       const error = { response: { data: { error: 'fail' } } };
       mockPost.mockResolvedValueOnce({ data: { success: false } });
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-      const { getByTestId } = render(<LoginForm />);
+      const { getByTestId } = render(<LoginNode />);
       fireEvent.submit(getByTestId('mock-form'));
       await waitFor(() => {
          expect(mockPost).toHaveBeenCalled();
@@ -65,7 +67,7 @@ describe('LoginForm', () => {
       const error = { response: { data: { error: 'fail' } } };
       mockPost.mockRejectedValueOnce(error);
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-      const { getByTestId } = render(<LoginForm />);
+      const { getByTestId } = render(<LoginNode />);
       fireEvent.submit(getByTestId('mock-form'));
       await waitFor(() => {
          expect(mockPost).toHaveBeenCalled();

--- a/src/components/forms/RegisterForm/RegisterForm.jsx
+++ b/src/components/forms/RegisterForm/RegisterForm.jsx
@@ -1,28 +1,9 @@
-import { useRouter } from 'next/navigation';
 import { FormControl, FormInput } from '@/components/common';
-import Ajax from '@/services/AJAX';
+import { useAuth } from '@/providers/AuthContext';
 
 export default function RegisterForm() {
-   const router = useRouter();
-
-   const handleSubmit = async (data) => {
-      const ajax = Ajax(process.env.NEXT_PUBLIC_API_ROOT);
-      
-      try {
-         const registerUser = await ajax.put('/auth/cadastro', data);
-
-         if (!registerUser.data.success) {
-            const errorData = registerUser.response ? registerUser.response.data : registerUser;
-            return errorData;
-         }
-
-         router.push('/');
-         return registerUser.data;
-      } catch (error) {
-         const errorData = error.response ? error.response.data : error;
-         return errorData;
-      }
-   };
+   const { register } = useAuth();
+   const handleSubmit = async (data) => await register(data);
 
    return (
       <FormControl submitLabel="Entrar" onSubmit={handleSubmit}>

--- a/src/components/forms/RegisterForm/RegisterForm.test.jsx
+++ b/src/components/forms/RegisterForm/RegisterForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import RegisterForm from './RegisterForm';
+import { AuthProvider } from '@/providers/AuthContext';
 
 // Mocks
 const mockPush = jest.fn();
@@ -32,13 +33,15 @@ jest.mock('@/components/common', () => ({
 }));
 
 describe('RegisterForm', () => {
+   const RegisterNode = () => <AuthProvider loadedUser={{ name: 'John', email: 'john@test.com' }} notAuthRender renderIfLoading><RegisterForm /></AuthProvider>;
+
    beforeEach(() => {
       mockPut.mockReset();
       mockPush.mockReset();
    });
 
    it('renders form and all inputs', () => {
-      const { getByTestId, getByText } = render(<RegisterForm />);
+      const { getByTestId, getByText } = render(<RegisterNode />);
       expect(getByTestId('mock-form')).toBeInTheDocument();
       expect(getByTestId('mock-input-firstName')).toBeInTheDocument();
       expect(getByTestId('mock-input-lastName')).toBeInTheDocument();
@@ -50,8 +53,9 @@ describe('RegisterForm', () => {
 
    it('submits form and redirects on success', async () => {
       mockPut.mockResolvedValueOnce({ data: { success: true } });
-      const { getByTestId } = render(<RegisterForm />);
-      fireEvent.submit(getByTestId('mock-form'));
+      const { container } = render(<RegisterNode />);
+      const form = container.querySelector('form');
+      fireEvent.submit(form);
       await waitFor(() => {
          expect(mockPut).toHaveBeenCalledWith('/auth/cadastro', {
             firstName: 'John',
@@ -67,8 +71,9 @@ describe('RegisterForm', () => {
    it('handles failed register and logs error', async () => {
       mockPut.mockResolvedValueOnce({ data: { success: false } });
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-      const { getByTestId } = render(<RegisterForm />);
-      fireEvent.submit(getByTestId('mock-form'));
+      const { container } = render(<RegisterNode />);
+      const form = container.querySelector('form');
+      fireEvent.submit(form);
       await waitFor(() => {
          expect(mockPut).toHaveBeenCalled();
       });
@@ -79,8 +84,9 @@ describe('RegisterForm', () => {
       const error = { response: { data: { error: 'fail' } } };
       mockPut.mockRejectedValueOnce(error);
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-      const { getByTestId } = render(<RegisterForm />);
-      fireEvent.submit(getByTestId('mock-form'));
+      const { container } = render(<RegisterNode />);
+      const form = container.querySelector('form');
+      fireEvent.submit(form);
       await waitFor(() => {
          expect(mockPut).toHaveBeenCalled();
       });

--- a/src/components/layout/PageBase/PageBase.jsx
+++ b/src/components/layout/PageBase/PageBase.jsx
@@ -8,15 +8,29 @@ import { AuthProvider } from "@/providers/AuthContext";
  *
  * @component
  * @param {Object} props - The component props.
- * @param {boolean} props.authProtected - Indicates whether the page requires authentication.
+ * @param {boolean} [props.useAuthentication=false] - If true, wraps the page in an `AuthProvider` for authentication context.
+ * @param {boolean} [props.redirectLogin=true] - If true, redirects to the login page if the user is not authenticated.
+ * @param {boolean} [props.notAuthRender=false] - If true, allows rendering of the page content even when not authenticated.
+ * @param {boolean} [props.renderIfLoading=false] - If true, renders the page content even while authentication is loading.
  * @param {React.ReactNode} props.children - The content to be displayed within the page layout.
  *
  * @returns {JSX.Element} A structured layout with a header and dynamic page content.
  */
-export default function PageBase({ authProtected, children }) {
-   if (authProtected) {
+export default function PageBase({
+   useAuthentication = false,
+   redirectLogin = true,
+   notAuthRender = false,
+   renderIfLoading = false,
+   children
+}) {
+   if (useAuthentication) {
       return (
-         <AuthProvider redirectLogin spinnerHeight="98vh">
+         <AuthProvider
+            spinnerHeight="98vh"
+            notAuthRender={notAuthRender}
+            redirectLogin={redirectLogin}
+            renderIfLoading={renderIfLoading}
+         >
             <div className="PageBase">
                <HeaderBase />
                {children}

--- a/src/components/layout/PageBase/PageBase.test.jsx
+++ b/src/components/layout/PageBase/PageBase.test.jsx
@@ -18,7 +18,7 @@ jest.mock('@/providers/AuthContext', () => ({
 }));
 
 describe('PageBase', () => {
-   it('renders header and children when not authProtected', () => {
+   it('renders header and children when not useAuthentication', () => {
       const { getByTestId, getByText, container } = render(
          <PageBase>Content</PageBase>
       );
@@ -27,9 +27,9 @@ describe('PageBase', () => {
       expect(getByText('Content')).toBeInTheDocument();
    });
 
-   it('wraps with AuthProvider when authProtected', () => {
+   it('wraps with AuthProvider when useAuthentication', () => {
       const { getByTestId, getByText, container } = render(
-         <PageBase authProtected>Secret</PageBase>
+         <PageBase useAuthentication>Secret</PageBase>
       );
       expect(getByTestId('mock-auth-provider')).toBeInTheDocument();
       expect(getByTestId('mock-header')).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe('PageBase', () => {
 
    it('passes correct props to AuthProvider', () => {
       const { getByTestId } = render(
-         <PageBase authProtected>Test</PageBase>
+         <PageBase useAuthentication>Test</PageBase>
       );
       const authProvider = getByTestId('mock-auth-provider');
       expect(authProvider.getAttribute('redirectlogin')).toBe('true');

--- a/src/components/menus/TopNavigation/TopNavigation.jsx
+++ b/src/components/menus/TopNavigation/TopNavigation.jsx
@@ -13,7 +13,6 @@ import { AuthProvider, useAuth } from '@/providers/AuthContext';
 export default function TopNavigation() {
    const auth = useAuth();
    const user = auth?.user;
-   const loading = auth?.loading;
 
    return (
       <nav>

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -17,7 +17,7 @@ export default function Login() {
   const META_URL = 'http://localhost/';
 
   return (
-    <PageBase>
+    <PageBase redirectLogin={false} useAuthentication notAuthRender renderIfLoading>
       <Head>
         <title>{META_TITLE}</title>
         <meta name="description" content={META_DESCRIPTION} />

--- a/src/pages/produto/importar.jsx
+++ b/src/pages/produto/importar.jsx
@@ -10,7 +10,7 @@ import { PageBase } from '@/components/layout';
  */
 export default function Import() {
    return (
-      <PageBase authProtected>
+      <PageBase useAuthentication>
          <ImportContent />
       </PageBase>
    );


### PR DESCRIPTION
## [COGF-56] Descrição
Agora as funcções de login e cadastro fazem parte to AuthContext

This pull request refactors the authentication flow across the application by centralizing logic in the `AuthProvider` and updating components to use the new context-based approach. The changes simplify the codebase, improve maintainability, and enhance flexibility in handling authentication-related behaviors.

### Authentication Refactor:

* **Centralized Authentication Logic**:
  - Added `login` and `register` methods to the `AuthProvider` for handling user authentication and registration. These methods replace the previous direct usage of the `Ajax` service in individual components. [[1]](diffhunk://#diff-4949151008e60187931a818af53fa929c53744324af486a2fba9dad52d729f98R22-R72) [[2]](diffhunk://#diff-4949151008e60187931a818af53fa929c53744324af486a2fba9dad52d729f98L49-R105)
  - Introduced new props (`notAuthRender`, `renderIfLoading`, `redirectLogin`) in `AuthProvider` to control rendering behavior based on authentication state.

* **Updated Components to Use `AuthProvider`**:
  - Replaced `Ajax` and `useRouter` with `useAuth` in `LoginForm` and `RegisterForm` components, delegating authentication logic to the `AuthProvider`. [[1]](diffhunk://#diff-f11d6f5641ea8e22324ef528b14799eb362dc06f0eea8d64ea77be80acde7f51L1-R2) [[2]](diffhunk://#diff-f11d6f5641ea8e22324ef528b14799eb362dc06f0eea8d64ea77be80acde7f51L13-R13) [[3]](diffhunk://#diff-0bf2d9965aec8b96f2ad7af24c7aac12a5c2eeb25ce846a816b63225c8692fd7L1-R6)
  - Updated `PageBase` to support new `AuthProvider` props, enabling more granular control over authentication-related rendering.

### Component-Specific Adjustments:

* **Simplified Navigation Logic**:
  - Removed unnecessary `loading` variable in `TopNavigation` since it is no longer used.

* **Page-Level Authentication Updates**:
  - Updated `login.jsx` and `produto/importar.jsx` pages to use the new `PageBase` props for handling authentication behavior. [[1]](diffhunk://#diff-3f184983a5e15b9aeb8f06f274a7593d9be451957d77e1361307d699c7f02625L20-R20) [[2]](diffhunk://#diff-5be6102df25d858cf5fde8cfda35f2e46fc14f1bf38322f605d92dda4aca8c94L13-R13)

[COGF-56]: https://feliperamosdev.atlassian.net/browse/COGF-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ